### PR TITLE
refactor: model config types on Commander's own typings

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -123,7 +123,7 @@ tasks:
       - build
     cmds:
       - echo "Running SEA for $PROJECT_NAME..."
-      - ~/.local/bin/$PROJECT_NAME hello
+      - ~/.local/bin/$PROJECT_NAME {{.CLI_ARGS | default "hello"}}
     vars:
       TARGET:
         sh: |

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,19 +1,34 @@
 [app]
 description = "A CLI template for bootstrapping Bun applications"
 name = "helloc"
-version = "0.2.4"
+version = "0.3.5"
 
 [[commands]]
 description = "Hello world command"
 name = "hello"
-subcommands = false
+
+[[commands.commands]]
+description = "Say hello to someone"
+name = "to"
+
+[[commands.commands.arguments]]
+name = "name"
+description = "The person to greet"
+required = true
+
+[[commands.commands.options]]
+flags = "-l, --loud"
+description = "Greet in uppercase"
+defaultValue = false
+
+[[commands.commands.options]]
+flags = "--no-logger"
+description = "Use plain console output instead of Winston logger"
 
 [[commands]]
 description = "Install tools"
 name = "install"
-subcommands = true
 
-[[commands.children]]
+[[commands.commands]]
 description = "Download and install Task"
 name = "task"
-subcommands = false

--- a/src/bin/hello.test.ts
+++ b/src/bin/hello.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
-import { hello } from "@/bin/hello";
+import { hello, helloTo } from "@/bin/hello";
+import { logger } from "@/lib/logger";
 
 let originalPath = process.env.PATH;
 
@@ -17,4 +18,55 @@ test("hello() updates PATH with expected entries", async () => {
   expect(process.env.PATH).toContain("/tmp/test-home/.local/bin");
   expect(process.env.PATH).toContain("/tmp/test-home/bin");
   expect(process.env.PATH).toContain("/usr/bin:/bin");
+});
+
+test("helloTo() greets the provided name", async () => {
+  const originalInfo = logger.info.bind(logger);
+  let loggedMessage = "";
+  logger.info = ((msg: string) => {
+    loggedMessage = msg;
+    return logger;
+  }) as typeof logger.info;
+
+  await helloTo("Alice");
+
+  expect(loggedMessage).toBe("Hello, Alice!");
+  logger.info = originalInfo;
+});
+
+test("helloTo() greets in uppercase when loud option is set", async () => {
+  const originalInfo = logger.info.bind(logger);
+  let loggedMessage = "";
+  logger.info = ((msg: string) => {
+    loggedMessage = msg;
+    return logger;
+  }) as typeof logger.info;
+
+  await helloTo("Bob", { loud: true });
+
+  expect(loggedMessage).toBe("HELLO, BOB!");
+  logger.info = originalInfo;
+});
+
+test("helloTo() uses console.log when logger option is false", async () => {
+  const originalLog = console.log;
+  let consoleMessage = "";
+  console.log = (msg: string) => {
+    consoleMessage = msg;
+  };
+
+  const originalInfo = logger.info.bind(logger);
+  let loggerCalled = false;
+  logger.info = (() => {
+    loggerCalled = true;
+    return logger;
+  }) as typeof logger.info;
+
+  await helloTo("Carol", { logger: false });
+
+  expect(consoleMessage).toBe("Hello, Carol!");
+  expect(loggerCalled).toBe(false);
+
+  console.log = originalLog;
+  logger.info = originalInfo;
 });

--- a/src/bin/hello.ts
+++ b/src/bin/hello.ts
@@ -1,6 +1,22 @@
 import { has, pathAdd } from "@/lib";
 import { logger } from "@/lib/logger";
 
+export interface HelloToOptions {
+  loud?: boolean;
+  logger?: boolean;
+}
+
+export async function helloTo(name: string, options?: HelloToOptions): Promise<void> {
+  const greeting = `Hello, ${name}!`;
+  const message = options?.loud ? greeting.toUpperCase() : greeting;
+
+  if (options?.logger === false) {
+    console.log(message);
+  } else {
+    logger.info(message);
+  }
+}
+
 export async function hello(): Promise<void> {
   // Using various log levels from the global logger
   logger.info("Hello world from info level!");

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,12 +1,12 @@
 import config from "config";
-import type { Config, AppConfig, Command } from "@/types/config";
+import type { Config, AppConfig, CommandDefinition } from "@/types/config";
 import { logger } from "@/lib/logger";
 
 // Load and validate the configuration
 export function loadConfig(): Config {
   try {
     const appConfig = config.get<AppConfig>("app");
-    const commands = config.get<Command[]>("commands");
+    const commands = config.get<CommandDefinition[]>("commands");
 
     return {
       app: appConfig,

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -13,17 +13,34 @@ function createBaseConfig(): Config {
       {
         name: "hello",
         description: "Hello command",
-        subcommands: false,
+        commands: [
+          {
+            name: "to",
+            description: "Say hello to someone",
+            arguments: [
+              {
+                name: "name",
+                description: "The person to greet",
+                required: true,
+              },
+            ],
+            options: [
+              {
+                flags: "-l, --loud",
+                description: "Greet in uppercase",
+                defaultValue: false,
+              },
+            ],
+          },
+        ],
       },
       {
         name: "install",
         description: "Install tools",
-        subcommands: true,
-        children: [
+        commands: [
           {
             name: "task",
             description: "Install task",
-            subcommands: false,
           },
         ],
       },
@@ -38,31 +55,35 @@ test("createProgram() registers known commands and subcommands", () => {
   expect(rootCommandNames).toContain("hello");
   expect(rootCommandNames).toContain("install");
 
+  const helloCommand = program.commands.find((cmd) => cmd.name() === "hello");
+  expect(helloCommand).toBeDefined();
+  expect(helloCommand?.commands.map((cmd) => cmd.name())).toContain("to");
+
+  const toCommand = helloCommand?.commands.find((cmd) => cmd.name() === "to");
+  expect(toCommand).toBeDefined();
+  expect(toCommand?.registeredArguments.length).toBe(1);
+  expect(toCommand?.registeredArguments[0]?.name()).toBe("name");
+  expect(toCommand?.registeredArguments[0]?.required).toBe(true);
+
   const installCommand = program.commands.find((cmd) => cmd.name() === "install");
   expect(installCommand).toBeDefined();
   expect(installCommand?.commands.map((cmd) => cmd.name())).toContain("task");
 });
 
-test("createProgram() throws on unknown command", () => {
-  const config: Config = {
-    app: {
-      name: "test-cli",
-      description: "Test CLI",
-      version: "1.0.0",
-    },
-    commands: [
-      {
-        name: "unknown",
-        description: "Unknown command",
-        subcommands: false,
-      },
-    ],
-  };
+test("createProgram() registers options on commands", () => {
+  const program = createProgram(createBaseConfig());
 
-  expect(() => createProgram(config)).toThrow("Unknown command: unknown");
+  const helloCommand = program.commands.find((cmd) => cmd.name() === "hello");
+  const toCommand = helloCommand?.commands.find((cmd) => cmd.name() === "to");
+  expect(toCommand).toBeDefined();
+
+  const loudOpt = toCommand?.options.find((o) => o.long === "--loud");
+  expect(loudOpt).toBeDefined();
+  expect(loudOpt?.short).toBe("-l");
+  expect(loudOpt?.description).toBe("Greet in uppercase");
 });
 
-test("createProgram() throws on unknown subcommand", () => {
+test("createProgram() registers arguments at any command level", () => {
   const config: Config = {
     app: {
       name: "test-cli",
@@ -71,19 +92,68 @@ test("createProgram() throws on unknown subcommand", () => {
     },
     commands: [
       {
-        name: "install",
-        description: "Install tools",
-        subcommands: true,
-        children: [
+        name: "greet",
+        description: "Greet someone",
+        arguments: [{ name: "who", description: "Person to greet", required: true }],
+        options: [{ flags: "-s, --shout", description: "Shout the greeting" }],
+        commands: [
           {
-            name: "unknown-sub",
-            description: "Unknown subcommand",
-            subcommands: false,
+            name: "formally",
+            description: "Formal greeting",
+            arguments: [{ name: "title", description: "Honorific", required: false }],
           },
         ],
       },
     ],
   };
 
-  expect(() => createProgram(config)).toThrow("Unknown subcommand: unknown-sub");
+  const program = createProgram(config);
+
+  const greetCmd = program.commands.find((c) => c.name() === "greet");
+  expect(greetCmd).toBeDefined();
+  expect(greetCmd?.registeredArguments[0]?.name()).toBe("who");
+  expect(greetCmd?.registeredArguments[0]?.required).toBe(true);
+  expect(greetCmd?.options.find((o) => o.long === "--shout")).toBeDefined();
+
+  const formallyCmd = greetCmd?.commands.find((c) => c.name() === "formally");
+  expect(formallyCmd).toBeDefined();
+  expect(formallyCmd?.registeredArguments[0]?.name()).toBe("title");
+  expect(formallyCmd?.registeredArguments[0]?.required).toBe(false);
+});
+
+test("createProgram() registers options at any command level", () => {
+  const config: Config = {
+    app: {
+      name: "test-cli",
+      description: "Test CLI",
+      version: "1.0.0",
+    },
+    commands: [
+      {
+        name: "deploy",
+        description: "Deploy the app",
+        options: [{ flags: "-e, --env <environment>", description: "Target env", required: true }],
+        commands: [
+          {
+            name: "preview",
+            description: "Preview deploy",
+            options: [{ flags: "--dry-run", description: "Simulate only" }],
+          },
+        ],
+      },
+    ],
+  };
+
+  const program = createProgram(config);
+
+  const deployCmd = program.commands.find((c) => c.name() === "deploy");
+  expect(deployCmd).toBeDefined();
+
+  const envOpt = deployCmd?.options.find((o) => o.long === "--env");
+  expect(envOpt).toBeDefined();
+  expect(envOpt?.mandatory).toBe(true);
+
+  const previewCmd = deployCmd?.commands.find((c) => c.name() === "preview");
+  expect(previewCmd).toBeDefined();
+  expect(previewCmd?.options.find((o) => o.long === "--dry-run")).toBeDefined();
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,16 @@
 import "@/globals";
 
 import { downloadAndInstallTask } from "@/bin/install";
+import { helloTo } from "@/bin/hello";
 import { Command } from "commander";
 import { hello } from "@/index";
 import { has } from "@/lib";
 import { appConfig } from "@/lib/config";
-import type { Config } from "@/types/config";
+import type { Config, CommandDefinition, ArgumentDefinition, OptionDefinition } from "@/types/config";
+
+// ---------------------------------------------------------------------------
+// Action handlers
+// ---------------------------------------------------------------------------
 
 async function handleHelloAction(): Promise<void> {
   await hello();
@@ -30,48 +35,87 @@ async function handleInstallTaskAction(): Promise<void> {
   }
 }
 
-function registerCommands(program: Command, config: Config): void {
-  config.commands.forEach((cmd) => {
-    switch (cmd.name) {
-      case "hello": {
-        program.command(cmd.name).description(cmd.description).action(handleHelloAction);
-        break;
-      }
-      case "install": {
-        const parentCommand = program.command(cmd.name).description(cmd.description);
+// ---------------------------------------------------------------------------
+// Action registry — maps "parent/child" command paths to action handlers.
+// Any command whose fully-qualified name is NOT in this map will be
+// registered without an action (it may still serve as a parent for
+// subcommands).
+// ---------------------------------------------------------------------------
 
-        cmd.children?.forEach((subCmd) => {
-          const command = parentCommand.command(subCmd.name).description(subCmd.description);
+type ActionHandler = (...args: any[]) => void | Promise<void>;
 
-          switch (subCmd.name) {
-            case "task": {
-              command.action(handleInstallTaskAction);
-              break;
-            }
-            default: {
-              const message = `Unknown subcommand: ${subCmd.name}`;
-              logger.error(message);
-              throw new Error(message);
-            }
-          }
-        });
+const actionRegistry = new Map<string, ActionHandler>([
+  ["hello", handleHelloAction],
+  [
+    "hello/to",
+    (name: string, opts: Record<string, unknown>) => helloTo(name, opts as { loud?: boolean; logger?: boolean }),
+  ],
+  ["install/task", handleInstallTaskAction],
+]);
 
-        break;
-      }
-      default: {
-        const message = `Unknown command: ${cmd.name}`;
-        logger.error(message);
-        throw new Error(message);
-      }
+// ---------------------------------------------------------------------------
+// Generic registration helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Register positional arguments from config onto a Commander command.
+ */
+function registerArguments(command: Command, args?: ArgumentDefinition[]): void {
+  if (!args) return;
+  for (const arg of args) {
+    const required = arg.required !== false;
+    const syntax = required ? `<${arg.name}>` : `[${arg.name}]`;
+    command.argument(syntax, arg.description ?? "", arg.defaultValue);
+  }
+}
+
+/**
+ * Register options / flags from config onto a Commander command.
+ */
+function registerOptions(command: Command, opts?: OptionDefinition[]): void {
+  if (!opts) return;
+  for (const opt of opts) {
+    if (opt.required) {
+      command.requiredOption(opt.flags, opt.description ?? "", opt.defaultValue as string);
+    } else {
+      command.option(opt.flags, opt.description ?? "", opt.defaultValue as string);
     }
-  });
+  }
+}
+
+/**
+ * Recursively register a command tree. Arguments and options are attached at
+ * every level. An action is attached only when the command's fully-qualified
+ * path (e.g. "install/task") exists in {@link actionRegistry}.
+ *
+ * @param parent   The Commander command to attach children to.
+ * @param defs     Array of {@link CommandDefinition} for this level.
+ * @param prefix   Slash-delimited path prefix used for action-registry lookup.
+ */
+function registerCommandTree(parent: Command, defs: CommandDefinition[], prefix = ""): void {
+  for (const def of defs) {
+    const cmd = parent.command(def.name).description(def.description);
+
+    registerArguments(cmd, def.arguments);
+    registerOptions(cmd, def.options);
+
+    const path = prefix ? `${prefix}/${def.name}` : def.name;
+    const action = actionRegistry.get(path);
+    if (action) {
+      cmd.action(action);
+    }
+
+    if (def.commands) {
+      registerCommandTree(cmd, def.commands, path);
+    }
+  }
 }
 
 export function createProgram(config: Config = appConfig): Command {
   const program = new Command();
 
   program.name(config.app.name).description(config.app.description).version(config.app.version);
-  registerCommands(program, config);
+  registerCommandTree(program, config.commands);
 
   return program;
 }


### PR DESCRIPTION
## Summary

Refactors the config type system to extend Commander's own typings, introduces recursive command registration, and adds support for positional arguments and option flags at any level of the command tree.

### Breaking Changes

- **`subcommands` boolean discriminator removed** — subcommand presence inferred from `commands` array
- **`children` renamed to `commands`** — aligns with Commander's `Command.commands`
- **Discriminated union types removed** — `CommandWithSubcommands` / `CommandWithoutSubcommands` replaced by single `CommandDefinition`

### Changes

- `CommandDefinition` extends Commander's `CommandOptions`
- New `ArgumentDefinition` type modeled after Commander's `Argument` class
- New `OptionDefinition` type modeled after Commander's `Option` class
- Arguments and options can be declared at any command tree level via TOML config
- Replaced hardcoded switch-based registration with recursive `registerCommandTree()`
- Action handlers mapped via slash-delimited path registry (`hello/to`, `install/task`)
- Added `hello to <name>` subcommand with `--loud` and `--no-logger` flags
- Taskfile `run` task now forwards CLI args (`task run -- hello to Bob --loud`)
- All tests updated; new tests for options, arguments at any depth, and `--no-logger`
- README rewritten with full schema table and examples
